### PR TITLE
fix: unable to delete last line of the file

### DIFF
--- a/actions.ts
+++ b/actions.ts
@@ -38,10 +38,20 @@ export const deleteSelectedLines = (editor: Editor) => {
     return;
   }
   const { from, to } = getSelectionBoundaries(selections[0]);
-  if (from.line === 0)
-    editor.replaceRange('', getLineStartPos(from.line), getLineStartPos(to.line + 1));
-  else
-    editor.replaceRange('', getLineEndPos(from.line - 1, editor), getLineEndPos(to.line, editor));
+  if (from.line === 0) {
+    // there is no 'previous line' when cursor is on the first line
+    editor.replaceRange(
+      '',
+      getLineStartPos(from.line),
+      getLineStartPos(to.line + 1),
+    );
+  } else {
+    editor.replaceRange(
+      '',
+      getLineEndPos(from.line - 1, editor),
+      getLineEndPos(to.line, editor),
+    );
+  }
 };
 
 export const joinLines = (editor: Editor) => {

--- a/actions.ts
+++ b/actions.ts
@@ -38,9 +38,10 @@ export const deleteSelectedLines = (editor: Editor) => {
     return;
   }
   const { from, to } = getSelectionBoundaries(selections[0]);
-  const startOfCurrentLine = getLineStartPos(from.line);
-  const startOfNextLine = getLineStartPos(to.line + 1);
-  editor.replaceRange('', startOfCurrentLine, startOfNextLine);
+  if (from.line === 0)
+    editor.replaceRange('', getLineStartPos(from.line), getLineStartPos(to.line + 1));
+  else
+    editor.replaceRange('', getLineEndPos(from.line - 1, editor), getLineEndPos(to.line, editor));
 };
 
 export const joinLines = (editor: Editor) => {


### PR DESCRIPTION
The command to delete the line did not work on the last line of the file.

The cause was that the plugin would always look for the newline character at the end of the line to delete, and the last line of the file does not have this character.

After modification, the plugin will now look for this character at the end of the previous line, except for the first line of the file where the old behavior is kept. 