### PR TITLE
Provide commands to move cursor to prev/next header.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ This [Obsidian](https://obsidian.md) plugin adds keyboard shortcuts (hotkeys) co
 | Transform selection to title case                | Not set                    |
 | Expand selection to brackets                     | Not set                    |
 | Expand selection to quotes                       | Not set                    |
+| Go to next heading                               | Not set                    |
+| Go to previous heading                           | Not set                    |
 
 \* On macOS, replace `Ctrl` with `Cmd`
 

--- a/actions.ts
+++ b/actions.ts
@@ -1,21 +1,21 @@
-import { Editor } from 'obsidian';
-import {
-  getLineStartPos,
-  getLineEndPos,
-  getSelectionBoundaries,
-  wordRangeAtPos,
-  getLeadingWhitespace,
-  findPosOfNextCharacter,
-  CheckCharacter,
-} from './utils';
+import { App, Editor, Vault } from 'obsidian';
 import {
   CASE,
   DIRECTION,
   LOWERCASE_ARTICLES,
-  MatchingCharacterMap,
   MATCHING_BRACKETS,
   MATCHING_QUOTES,
+  MatchingCharacterMap,
 } from './constants';
+import {
+  CheckCharacter,
+  findPosOfNextCharacter,
+  getLeadingWhitespace,
+  getLineEndPos,
+  getLineStartPos,
+  getSelectionBoundaries,
+  wordRangeAtPos,
+} from './utils';
 
 export const insertLineAbove = (editor: Editor) => {
   const { line } = editor.getCursor();
@@ -97,6 +97,31 @@ export const goToLineBoundary = (editor: Editor, boundary: 'start' | 'end') => {
   const { line } = editor.getCursor('from');
   editor.setSelection(
     boundary === 'start' ? getLineStartPos(line) : getLineEndPos(line, editor),
+  );
+};
+
+export const goToHeader = (
+  app: App,
+  editor: Editor,
+  boundary: 'prev' | 'next',
+) => {
+  const { line } = editor.getCursor('from');
+  const file = app.metadataCache.getFileCache(app.workspace.getActiveFile());
+
+  let prevHeaderLine = file.headings?.length > 0 ? 0 : line;
+  let nextHeaderLine = file.headings?.length > 0 ? editor.lastLine() : line;
+
+  file.headings.forEach(({ position }) => {
+    const { start, end } = position;
+    if (line - end.line > 0 && line - end.line < line - prevHeaderLine)
+      prevHeaderLine = end.line;
+    if (end.line - line > 0 && end.line - line < nextHeaderLine - line)
+      nextHeaderLine = end.line;
+  });
+  editor.setSelection(
+    boundary === 'prev'
+      ? getLineEndPos(prevHeaderLine, editor)
+      : getLineEndPos(nextHeaderLine, editor),
   );
 };
 

--- a/actions.ts
+++ b/actions.ts
@@ -100,28 +100,34 @@ export const goToLineBoundary = (editor: Editor, boundary: 'start' | 'end') => {
   );
 };
 
-export const goToHeader = (
+export const goToHeading = (
   app: App,
   editor: Editor,
   boundary: 'prev' | 'next',
 ) => {
-  const { line } = editor.getCursor('from');
   const file = app.metadataCache.getFileCache(app.workspace.getActiveFile());
+  if (!file.headings || file.headings.length === 0) {
+    return;
+  }
 
-  let prevHeaderLine = file.headings?.length > 0 ? 0 : line;
-  let nextHeaderLine = file.headings?.length > 0 ? editor.lastLine() : line;
+  const { line } = editor.getCursor('from');
+  let prevHeadingLine = 0;
+  let nextHeadingLine = editor.lastLine();
 
   file.headings.forEach(({ position }) => {
-    const { start, end } = position;
-    if (line - end.line > 0 && line - end.line < line - prevHeaderLine)
-      prevHeaderLine = end.line;
-    if (end.line - line > 0 && end.line - line < nextHeaderLine - line)
-      nextHeaderLine = end.line;
+    const { end: headingPos } = position;
+    if (line > headingPos.line && headingPos.line > prevHeadingLine) {
+      prevHeadingLine = headingPos.line;
+    }
+    if (line < headingPos.line && headingPos.line < nextHeadingLine) {
+      nextHeadingLine = headingPos.line;
+    }
   });
+
   editor.setSelection(
     boundary === 'prev'
-      ? getLineEndPos(prevHeaderLine, editor)
-      : getLineEndPos(nextHeaderLine, editor),
+      ? getLineEndPos(prevHeadingLine, editor)
+      : getLineEndPos(nextHeadingLine, editor),
   );
 };
 

--- a/actions.ts
+++ b/actions.ts
@@ -100,37 +100,6 @@ export const goToLineBoundary = (editor: Editor, boundary: 'start' | 'end') => {
   );
 };
 
-export const goToHeading = (
-  app: App,
-  editor: Editor,
-  boundary: 'prev' | 'next',
-) => {
-  const file = app.metadataCache.getFileCache(app.workspace.getActiveFile());
-  if (!file.headings || file.headings.length === 0) {
-    return;
-  }
-
-  const { line } = editor.getCursor('from');
-  let prevHeadingLine = 0;
-  let nextHeadingLine = editor.lastLine();
-
-  file.headings.forEach(({ position }) => {
-    const { end: headingPos } = position;
-    if (line > headingPos.line && headingPos.line > prevHeadingLine) {
-      prevHeadingLine = headingPos.line;
-    }
-    if (line < headingPos.line && headingPos.line < nextHeadingLine) {
-      nextHeadingLine = headingPos.line;
-    }
-  });
-
-  editor.setSelection(
-    boundary === 'prev'
-      ? getLineEndPos(prevHeadingLine, editor)
-      : getLineEndPos(nextHeadingLine, editor),
-  );
-};
-
 export const transformCase = (editor: Editor, caseType: CASE) => {
   const originalSelections = editor.listSelections();
   let selectedText = editor.getSelection();
@@ -229,3 +198,34 @@ export const expandSelectionToQuotes = (editor: Editor) =>
     openingCharacterCheck: (char: string) => /['"`]/.test(char),
     matchingCharacterMap: MATCHING_QUOTES,
   });
+
+export const goToHeading = (
+  app: App,
+  editor: Editor,
+  boundary: 'prev' | 'next',
+) => {
+  const file = app.metadataCache.getFileCache(app.workspace.getActiveFile());
+  if (!file.headings || file.headings.length === 0) {
+    return;
+  }
+
+  const { line } = editor.getCursor('from');
+  let prevHeadingLine = 0;
+  let nextHeadingLine = editor.lastLine();
+
+  file.headings.forEach(({ position }) => {
+    const { end: headingPos } = position;
+    if (line > headingPos.line && headingPos.line > prevHeadingLine) {
+      prevHeadingLine = headingPos.line;
+    }
+    if (line < headingPos.line && headingPos.line < nextHeadingLine) {
+      nextHeadingLine = headingPos.line;
+    }
+  });
+
+  editor.setSelection(
+    boundary === 'prev'
+      ? getLineEndPos(prevHeadingLine, editor)
+      : getLineEndPos(nextHeadingLine, editor),
+  );
+};

--- a/main.ts
+++ b/main.ts
@@ -3,7 +3,7 @@ import {
   duplicateLine,
   expandSelectionToBrackets,
   expandSelectionToQuotes,
-  goToHeader,
+  goToHeading,
   goToLineBoundary,
   insertLineAbove,
   insertLineBelow,
@@ -102,15 +102,15 @@ export default class CodeEditorShortcuts extends Plugin {
     });
 
     this.addCommand({
-      id: 'goToNextHeader',
-      name: 'Go to next header',
-      editorCallback: (editor) => goToHeader(this.app, editor, 'next'),
+      id: 'goToNextHeading',
+      name: 'Go to next heading',
+      editorCallback: (editor) => goToHeading(this.app, editor, 'next'),
     });
 
     this.addCommand({
-      id: 'goToPrevHeader',
-      name: 'Go to prev header',
-      editorCallback: (editor) => goToHeader(this.app, editor, 'prev'),
+      id: 'goToPrevHeading',
+      name: 'Go to previous heading',
+      editorCallback: (editor) => goToHeading(this.app, editor, 'prev'),
     });
 
     this.addCommand({

--- a/main.ts
+++ b/main.ts
@@ -1,3 +1,4 @@
+import { Plugin } from 'obsidian';
 import {
   deleteSelectedLines,
   duplicateLine,
@@ -11,9 +12,7 @@ import {
   selectLine,
   transformCase,
 } from './actions';
-
 import { CASE } from './constants';
-import { Plugin } from 'obsidian';
 
 export default class CodeEditorShortcuts extends Plugin {
   onload() {
@@ -102,18 +101,6 @@ export default class CodeEditorShortcuts extends Plugin {
     });
 
     this.addCommand({
-      id: 'goToNextHeading',
-      name: 'Go to next heading',
-      editorCallback: (editor) => goToHeading(this.app, editor, 'next'),
-    });
-
-    this.addCommand({
-      id: 'goToPrevHeading',
-      name: 'Go to previous heading',
-      editorCallback: (editor) => goToHeading(this.app, editor, 'prev'),
-    });
-
-    this.addCommand({
       id: 'transformToUppercase',
       name: 'Transform selection to uppercase',
       editorCallback: (editor) => transformCase(editor, CASE.UPPER),
@@ -141,6 +128,18 @@ export default class CodeEditorShortcuts extends Plugin {
       id: 'expandSelectionToQuotes',
       name: 'Expand selection to quotes',
       editorCallback: (editor) => expandSelectionToQuotes(editor),
+    });
+
+    this.addCommand({
+      id: 'goToNextHeading',
+      name: 'Go to next heading',
+      editorCallback: (editor) => goToHeading(this.app, editor, 'next'),
+    });
+
+    this.addCommand({
+      id: 'goToPrevHeading',
+      name: 'Go to previous heading',
+      editorCallback: (editor) => goToHeading(this.app, editor, 'prev'),
     });
   }
 }

--- a/main.ts
+++ b/main.ts
@@ -1,17 +1,19 @@
-import { Plugin } from 'obsidian';
 import {
-  insertLineAbove,
-  insertLineBelow,
   deleteSelectedLines,
-  joinLines,
   duplicateLine,
-  selectLine,
-  transformCase,
-  goToLineBoundary,
   expandSelectionToBrackets,
   expandSelectionToQuotes,
+  goToHeader,
+  goToLineBoundary,
+  insertLineAbove,
+  insertLineBelow,
+  joinLines,
+  selectLine,
+  transformCase,
 } from './actions';
+
 import { CASE } from './constants';
+import { Plugin } from 'obsidian';
 
 export default class CodeEditorShortcuts extends Plugin {
   onload() {
@@ -97,6 +99,18 @@ export default class CodeEditorShortcuts extends Plugin {
       id: 'goToLineEnd',
       name: 'Go to end of line',
       editorCallback: (editor) => goToLineBoundary(editor, 'end'),
+    });
+
+    this.addCommand({
+      id: 'goToNextHeader',
+      name: 'Go to next header',
+      editorCallback: (editor) => goToHeader(this.app, editor, 'next'),
+    });
+
+    this.addCommand({
+      id: 'goToPrevHeader',
+      name: 'Go to prev header',
+      editorCallback: (editor) => goToHeader(this.app, editor, 'prev'),
     });
 
     this.addCommand({


### PR DESCRIPTION
With this update, user will be able to move cursor to the prev/next closest header in a note in editor mode.
Those commands can be assigned to hotkeys (presonally, I prefer Alt+Up/Down, as in Intellij IDEA).
I really want to have this feature and I haven't found any other implementation of it in Obsidian.