### PR TITLE
Add support for copying lines up and down

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ This [Obsidian](https://obsidian.md) plugin adds keyboard shortcuts (hotkeys) co
 | Insert line above                                | `Ctrl` + `Shift` + `Enter` |
 | Delete line                                      | `Ctrl` + `Shift` + `K`     |
 | Duplicate line                                   | `Ctrl` + `Shift` + `D`     |
+| Copy line up                                     | `Alt` + `Shift` + `Up`     |
+| Copy line down                                   | `Alt` + `Shift` + `Down`   |
 | Join line below to current line                  | `Ctrl` + `J`               |
 | Select line (repeat to keep expanding selection) | `Ctrl` + `L`               |
 | Select word                                      | Not set                    |
@@ -24,6 +26,8 @@ This [Obsidian](https://obsidian.md) plugin adds keyboard shortcuts (hotkeys) co
 \* On macOS, replace `Ctrl` with `Cmd`
 
 \*\* This may conflict with the default shortcut for _Toggle checklist status_; changing/removing one of the bindings is recommended
+
+If you are looking for the `Alt` + `Up` and `Alt` + `Down` shortcuts from VS Code, you can assign those hotkeys to Obsidian's built in actions "Swap line up" and "Swap line down".
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This [Obsidian](https://obsidian.md) plugin adds keyboard shortcuts (hotkeys) co
 | Go to next heading                               | Not set                    |
 | Go to previous heading                           | Not set                    |
 
-\* On macOS, replace `Ctrl` with `Cmd`
+\* On macOS, replace `Ctrl` with `Cmd` and `Alt` with `Opt`
 
 \*\* This may conflict with the default shortcut for _Toggle checklist status_; changing/removing one of the bindings is recommended
 

--- a/src/__tests__/actions.spec.ts
+++ b/src/__tests__/actions.spec.ts
@@ -6,8 +6,7 @@ import {
   insertLineBelow,
   deleteSelectedLines,
   joinLines,
-  copyLineUp,
-  copyLineDown,
+  copyLine,
   selectWord,
   selectLine,
   goToLineBoundary,
@@ -123,7 +122,7 @@ describe('Code Editor Shortcuts: actions', () => {
     it('should copy current line up', () => {
       editor.setCursor({ line: 1, ch: 3 });
 
-      copyLineUp(editor as any);
+      copyLine(editor as any, 'up');
 
       const { doc, cursor } = getDocumentAndSelection(editor);
       expect(doc).toEqual('lorem ipsum\ndolor sit\ndolor sit\namet');
@@ -134,7 +133,7 @@ describe('Code Editor Shortcuts: actions', () => {
     it('should copy current line up from the end of a line', () => {
       editor.setCursor({ line: 1, ch: 9 });
 
-      copyLineUp(editor as any);
+      copyLine(editor as any, 'up');
 
       const { doc, cursor } = getDocumentAndSelection(editor);
       expect(doc).toEqual('lorem ipsum\ndolor sit\ndolor sit\namet');
@@ -145,7 +144,7 @@ describe('Code Editor Shortcuts: actions', () => {
     it('should copy current line down', () => {
       editor.setCursor({ line: 1, ch: 3 });
 
-      copyLineDown(editor as any);
+      copyLine(editor as any, 'down');
 
       const { doc, cursor } = getDocumentAndSelection(editor);
       expect(doc).toEqual('lorem ipsum\ndolor sit\ndolor sit\namet');
@@ -341,7 +340,7 @@ describe('Code Editor Shortcuts: actions', () => {
     });
 
     it('should copy selected lines up', () => {
-      copyLineUp(editor as any);
+      copyLine(editor as any, 'up');
 
       const { doc, selections } = getDocumentAndSelection(editor);
       expect(doc).toEqual(
@@ -356,7 +355,7 @@ describe('Code Editor Shortcuts: actions', () => {
     });
 
     it('should copy selected lines down', () => {
-      copyLineDown(editor as any);
+      copyLine(editor as any, 'down');
 
       const { doc, selections } = getDocumentAndSelection(editor);
       expect(doc).toEqual(

--- a/src/__tests__/actions.spec.ts
+++ b/src/__tests__/actions.spec.ts
@@ -6,7 +6,8 @@ import {
   insertLineBelow,
   deleteSelectedLines,
   joinLines,
-  duplicateLine,
+  copyLineUp,
+  copyLineDown,
   selectWord,
   selectLine,
   goToLineBoundary,
@@ -119,12 +120,24 @@ describe('Code Editor Shortcuts: actions', () => {
       expect(cursor.ch).toEqual(9);
     });
 
-    it('should duplicate current line', () => {
-      duplicateLine(editor as any);
+    it('should copy current line up', () => {
+      copyLineUp(editor as any);
+      editor.setCursor({ line: 1, ch: 3 });
+
+      const { doc, cursor } = getDocumentAndSelection(editor);
+      expect(doc).toEqual('lorem ipsum\ndolor sit\ndolor sit\namet');
+      expect(cursor.line).toEqual(1);
+      expect(cursor.ch).toEqual(3);
+    });
+
+    it('should copy current line down', () => {
+      editor.setCursor({ line: 1, ch: 3 });
+      copyLineDown(editor as any);
 
       const { doc, cursor } = getDocumentAndSelection(editor);
       expect(doc).toEqual('lorem ipsum\ndolor sit\ndolor sit\namet');
       expect(cursor.line).toEqual(2);
+      expect(cursor.ch).toEqual(3);
     });
 
     it('should select word', () => {
@@ -312,21 +325,6 @@ describe('Code Editor Shortcuts: actions', () => {
       expect(doc).toEqual('lorem ipsum\ndolor sit amet');
       expect(cursor.line).toEqual(1);
       expect(cursor.ch).toEqual(9);
-    });
-
-    it('should duplicate selected lines', () => {
-      duplicateLine(editor as any);
-
-      const { doc, selections } = getDocumentAndSelection(editor);
-      expect(doc).toEqual(
-        'lorem ipsum\ndolor sit\nlorem ipsum\ndolor sit\namet',
-      );
-      expect(selections[0].anchor).toEqual(
-        expect.objectContaining({ line: 2, ch: 6 }),
-      );
-      expect(selections[0].head).toEqual(
-        expect.objectContaining({ line: 3, ch: 5 }),
-      );
     });
 
     it('should not select additional words', () => {

--- a/src/__tests__/actions.spec.ts
+++ b/src/__tests__/actions.spec.ts
@@ -121,8 +121,9 @@ describe('Code Editor Shortcuts: actions', () => {
     });
 
     it('should copy current line up', () => {
-      copyLineUp(editor as any);
       editor.setCursor({ line: 1, ch: 3 });
+
+      copyLineUp(editor as any);
 
       const { doc, cursor } = getDocumentAndSelection(editor);
       expect(doc).toEqual('lorem ipsum\ndolor sit\ndolor sit\namet');
@@ -130,8 +131,20 @@ describe('Code Editor Shortcuts: actions', () => {
       expect(cursor.ch).toEqual(3);
     });
 
+    it('should copy current line up from the end of a line', () => {
+      editor.setCursor({ line: 1, ch: 9 });
+
+      copyLineUp(editor as any);
+
+      const { doc, cursor } = getDocumentAndSelection(editor);
+      expect(doc).toEqual('lorem ipsum\ndolor sit\ndolor sit\namet');
+      expect(cursor.line).toEqual(1);
+      expect(cursor.ch).toEqual(9);
+    });
+
     it('should copy current line down', () => {
       editor.setCursor({ line: 1, ch: 3 });
+
       copyLineDown(editor as any);
 
       const { doc, cursor } = getDocumentAndSelection(editor);

--- a/src/__tests__/actions.spec.ts
+++ b/src/__tests__/actions.spec.ts
@@ -340,6 +340,36 @@ describe('Code Editor Shortcuts: actions', () => {
       expect(cursor.ch).toEqual(9);
     });
 
+    it('should copy selected lines up', () => {
+      copyLineUp(editor as any);
+
+      const { doc, selections } = getDocumentAndSelection(editor);
+      expect(doc).toEqual(
+        'lorem ipsum\ndolor sit\nlorem ipsum\ndolor sit\namet',
+      );
+      expect(selections[0]).toEqual(
+        expect.objectContaining({
+          anchor: expect.objectContaining({ line: 0, ch: 6 }),
+          head: expect.objectContaining({ line: 1, ch: 5 }),
+        }),
+      );
+    });
+
+    it('should copy selected lines down', () => {
+      copyLineDown(editor as any);
+
+      const { doc, selections } = getDocumentAndSelection(editor);
+      expect(doc).toEqual(
+        'lorem ipsum\ndolor sit\nlorem ipsum\ndolor sit\namet',
+      );
+      expect(selections[0]).toEqual(
+        expect.objectContaining({
+          anchor: expect.objectContaining({ line: 2, ch: 6 }),
+          head: expect.objectContaining({ line: 3, ch: 5 }),
+        }),
+      );
+    });
+
     it('should not select additional words', () => {
       selectWord(editor as any);
 

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -69,7 +69,7 @@ export const joinLines = (editor: Editor) => {
   editor.setSelection(endOfCurrentLine);
 };
 
-export const copyLineUp = (editor: Editor) => {
+export const copyLine = (editor: Editor, direction: 'up' | 'down') => {
   const selections = editor.listSelections();
   if (selections.length === 0) {
     return;
@@ -78,20 +78,12 @@ export const copyLineUp = (editor: Editor) => {
   const fromLineStart = getLineStartPos(from.line);
   const toLineEnd = getLineEndPos(to.line, editor);
   const contentsOfSelectedLines = editor.getRange(fromLineStart, toLineEnd);
-  editor.replaceRange('\n' + contentsOfSelectedLines, toLineEnd);
-  editor.setSelections(selections);
-};
-
-export const copyLineDown = (editor: Editor) => {
-  const selections = editor.listSelections();
-  if (selections.length === 0) {
-    return;
+  if (direction === 'up') {
+    editor.replaceRange('\n' + contentsOfSelectedLines, toLineEnd);
+    editor.setSelections(selections);
+  } else {
+    editor.replaceRange(contentsOfSelectedLines + '\n', fromLineStart);
   }
-  const { from, to } = getSelectionBoundaries(selections[0]);
-  const fromLineStart = getLineStartPos(from.line);
-  const toLineEnd = getLineEndPos(to.line, editor);
-  const contentsOfSelectedLines = editor.getRange(fromLineStart, toLineEnd);
-  editor.replaceRange(contentsOfSelectedLines + '\n', fromLineStart);
 };
 
 export const selectWord = (editor: Editor) => {

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -69,7 +69,19 @@ export const joinLines = (editor: Editor) => {
   editor.setSelection(endOfCurrentLine);
 };
 
-export const duplicateLine = (editor: Editor) => {
+export const copyLineUp = (editor: Editor) => {
+  const selections = editor.listSelections();
+  if (selections.length === 0) {
+    return;
+  }
+  const { from, to } = getSelectionBoundaries(selections[0]);
+  const fromLineStart = getLineStartPos(from.line);
+  const toLineEnd = getLineEndPos(to.line, editor);
+  const contentsOfSelectedLines = editor.getRange(fromLineStart, toLineEnd);
+  editor.replaceRange('\n' + contentsOfSelectedLines, toLineEnd);
+};
+
+export const copyLineDown = (editor: Editor) => {
   const selections = editor.listSelections();
   if (selections.length === 0) {
     return;

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -79,6 +79,7 @@ export const copyLineUp = (editor: Editor) => {
   const toLineEnd = getLineEndPos(to.line, editor);
   const contentsOfSelectedLines = editor.getRange(fromLineStart, toLineEnd);
   editor.replaceRange('\n' + contentsOfSelectedLines, toLineEnd);
+  editor.setSelections(selections);
 };
 
 export const copyLineDown = (editor: Editor) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,6 @@
 import { Plugin } from 'obsidian';
 import {
-  copyLineUp,
-  copyLineDown,
+  copyLine,
   deleteSelectedLines,
   expandSelectionToBrackets,
   expandSelectionToQuotes,
@@ -75,7 +74,7 @@ export default class CodeEditorShortcuts extends Plugin {
           key: 'D',
         },
       ],
-      editorCallback: (editor) => copyLineDown(editor),
+      editorCallback: (editor) => copyLine(editor, 'down'),
     });
 
     this.addCommand({
@@ -87,7 +86,7 @@ export default class CodeEditorShortcuts extends Plugin {
           key: 'ArrowUp',
         },
       ],
-      editorCallback: (editor) => copyLineUp(editor),
+      editorCallback: (editor) => copyLine(editor, 'up'),
     });
 
     this.addCommand({
@@ -99,7 +98,7 @@ export default class CodeEditorShortcuts extends Plugin {
           key: 'ArrowDown',
         },
       ],
-      editorCallback: (editor) => copyLineDown(editor),
+      editorCallback: (editor) => copyLine(editor, 'down'),
     });
 
     this.addCommand({

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,8 @@
 import { Plugin } from 'obsidian';
 import {
+  copyLineUp,
+  copyLineDown,
   deleteSelectedLines,
-  duplicateLine,
   expandSelectionToBrackets,
   expandSelectionToQuotes,
   goToHeading,
@@ -74,7 +75,31 @@ export default class CodeEditorShortcuts extends Plugin {
           key: 'D',
         },
       ],
-      editorCallback: (editor) => duplicateLine(editor),
+      editorCallback: (editor) => copyLineDown(editor),
+    });
+
+    this.addCommand({
+      id: 'copyLineUp',
+      name: 'Copy line up',
+      hotkeys: [
+        {
+          modifiers: ['Alt', 'Shift'],
+          key: 'ArrowUp',
+        },
+      ],
+      editorCallback: (editor) => copyLineUp(editor),
+    });
+
+    this.addCommand({
+      id: 'copyLineDown',
+      name: 'Copy line down',
+      hotkeys: [
+        {
+          modifiers: ['Alt', 'Shift'],
+          key: 'ArrowDown',
+        },
+      ],
+      editorCallback: (editor) => copyLineDown(editor),
     });
 
     this.addCommand({


### PR DESCRIPTION
I customized this to meet my needs better:

* Changed Mod+J to Ctrl+J because VS Code uses Ctrl+J even on macOS.
* Added Alt+Up/Down for moving lines like in VS Code.
* Replaced Ctrl+Shift+D with Alt+Shift+Up/Down like in VS Code.

I realized you probably won't want to merge this as-is since it will break what users currently expect (Ctrl-Shift-D) but feel free to incorporate it somehow if you wish.

Also, I can't get tests to work. I'm getting `TypeError: editor.transaction is not a function`. But it works when I test the plugin manually.