### PR TITLE
Add Emacs shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
 # Code Editor Shortcuts
 
-This [Obsidian](https://obsidian.md) plugin adds keyboard shortcuts (hotkeys) commonly found in code editors such as Visual Studio Code, Sublime Text, Emacs or Vim.
+This [Obsidian](https://obsidian.md) plugin adds keyboard shortcuts (hotkeys) commonly found in code editors such as Visual Studio Code or Sublime Text.
 
 | Command                                          | Shortcut \*                |
 | ------------------------------------------------ | -------------------------- |
 | Insert line below                                | `Ctrl` + `Enter` \*\*      |
 | Insert line above                                | `Ctrl` + `Shift` + `Enter` |
 | Delete line                                      | `Ctrl` + `Shift` + `K`     |
-| Delete to end of line                            | Not set                    |
 | Duplicate line                                   | `Ctrl` + `Shift` + `D`     |
 | Copy line up                                     | `Alt` + `Shift` + `Up`     |
 | Copy line down                                   | `Alt` + `Shift` + `Down`   |
@@ -20,6 +19,7 @@ This [Obsidian](https://obsidian.md) plugin adds keyboard shortcuts (hotkeys) co
 | Go to end of line                                | Not set                    |
 | Go to previous line                              | Not set                    |
 | Go to next line                                  | Not set                    |
+| Delete to end of line                            | Not set                    |
 | Transform selection to uppercase                 | Not set                    |
 | Transform selection to lowercase                 | Not set                    |
 | Transform selection to title case                | Not set                    |

--- a/README.md
+++ b/README.md
@@ -1,20 +1,25 @@
 # Code Editor Shortcuts
 
-This [Obsidian](https://obsidian.md) plugin adds keyboard shortcuts (hotkeys) commonly found in code editors such as Visual Studio Code or Sublime Text.
+This [Obsidian](https://obsidian.md) plugin adds keyboard shortcuts (hotkeys) commonly found in code editors such as Visual Studio Code, Sublime Text, Emacs or Vim.
 
 | Command                                          | Shortcut \*                |
 | ------------------------------------------------ | -------------------------- |
 | Insert line below                                | `Ctrl` + `Enter` \*\*      |
 | Insert line above                                | `Ctrl` + `Shift` + `Enter` |
 | Delete line                                      | `Ctrl` + `Shift` + `K`     |
+| Delete to end of line                            | Not set                    |
 | Duplicate line                                   | `Ctrl` + `Shift` + `D`     |
 | Copy line up                                     | `Alt` + `Shift` + `Up`     |
 | Copy line down                                   | `Alt` + `Shift` + `Down`   |
 | Join line below to current line                  | `Ctrl` + `J`               |
 | Select line (repeat to keep expanding selection) | `Ctrl` + `L`               |
 | Select word                                      | Not set                    |
+| Move cursor left                                 | Not set                    |
+| Move cursor right                                | Not set                    |
 | Go to start of line                              | Not set                    |
 | Go to end of line                                | Not set                    |
+| Go to previous line                              | Not set                    |
+| Go to next line                                  | Not set                    |
 | Transform selection to uppercase                 | Not set                    |
 | Transform selection to lowercase                 | Not set                    |
 | Transform selection to title case                | Not set                    |

--- a/src/__tests__/actions.spec.ts
+++ b/src/__tests__/actions.spec.ts
@@ -5,6 +5,7 @@ import {
   insertLineAbove,
   insertLineBelow,
   deleteSelectedLines,
+  deleteToEndOfLine,
   joinLines,
   copyLine,
   selectWord,
@@ -110,6 +111,30 @@ describe('Code Editor Shortcuts: actions', () => {
       const { doc, cursor } = getDocumentAndSelection(editor);
       expect(doc).toEqual('lorem ipsum\ndolor sit');
       expect(cursor.line).toEqual(1);
+    });
+
+    it('should delete to the end of the line', () => {
+      editor.setCursor({ line: 1, ch: 1 });
+      deleteToEndOfLine(editor as any);
+
+      const { doc } = getDocumentAndSelection(editor);
+      expect(doc).toEqual('lorem ipsum\nd\namet');
+    });
+
+    it('should delete the newline when at the end of the line', () => {
+      editor.setCursor({ line: 1, ch: 9 });
+      deleteToEndOfLine(editor as any);
+
+      const { doc } = getDocumentAndSelection(editor);
+      expect(doc).toEqual('lorem ipsum\ndolor sitamet');
+    });
+
+    it('should delete nothing when at the end of the document', () => {
+      editor.setCursor({ line: 2, ch: 4 });
+      deleteToEndOfLine(editor as any);
+
+      const { doc } = getDocumentAndSelection(editor);
+      expect(doc).toEqual('lorem ipsum\ndolor sit\namet');
     });
 
     it('should join next line to current line', () => {

--- a/src/__tests__/actions.spec.ts
+++ b/src/__tests__/actions.spec.ts
@@ -11,6 +11,7 @@ import {
   selectLine,
   goToLineBoundary,
   navigateLine,
+  moveCursor,
   transformCase,
   expandSelectionToBrackets,
   expandSelectionToQuotes,
@@ -225,6 +226,64 @@ describe('Code Editor Shortcuts: actions', () => {
       const { cursor } = getDocumentAndSelection(editor);
       expect(cursor.line).toEqual(1);
       expect(cursor.ch).toEqual(2);
+    });
+
+    it('should navigate the cursor backward', () => {
+      editor.setCursor({ line: 2, ch: 2 });
+      moveCursor(editor as any, 'backward');
+
+      const { doc, cursor } = getDocumentAndSelection(editor);
+      expect(doc).toEqual(originalDoc);
+      expect(cursor.line).toEqual(2);
+      expect(cursor.ch).toEqual(1);
+    });
+
+    it('should navigate the cursor backward over a line boundary', () => {
+      moveCursor(editor as any, 'backward');
+
+      const { doc, cursor } = getDocumentAndSelection(editor);
+      expect(doc).toEqual(originalDoc);
+      expect(cursor.line).toEqual(0);
+      expect(cursor.ch).toEqual(11);
+    });
+
+    it('should not attempt to navigate the cursor past start of document', () => {
+      editor.setCursor({ line: 0, ch: 0 });
+      moveCursor(editor as any, 'backward');
+
+      const { doc, cursor } = getDocumentAndSelection(editor);
+      expect(doc).toEqual(originalDoc);
+      expect(cursor.line).toEqual(0);
+      expect(cursor.ch).toEqual(0);
+    });
+
+    it('should navigate the cursor forward', () => {
+      moveCursor(editor as any, 'forward');
+
+      const { doc, cursor } = getDocumentAndSelection(editor);
+      expect(doc).toEqual(originalDoc);
+      expect(cursor.line).toEqual(1);
+      expect(cursor.ch).toEqual(1);
+    });
+
+    it('should navigate the cursor forward over a line boundary', () => {
+      editor.setCursor({ line: 1, ch: 9 });
+      moveCursor(editor as any, 'forward');
+
+      const { doc, cursor } = getDocumentAndSelection(editor);
+      expect(doc).toEqual(originalDoc);
+      expect(cursor.line).toEqual(2);
+      expect(cursor.ch).toEqual(0);
+    });
+
+    it('should not attempt to navigate the cursor past end of document', () => {
+      editor.setCursor({ line: 2, ch: 4 });
+      moveCursor(editor as any, 'forward');
+
+      const { doc, cursor } = getDocumentAndSelection(editor);
+      expect(doc).toEqual(originalDoc);
+      expect(cursor.line).toEqual(2);
+      expect(cursor.ch).toEqual(4);
     });
 
     it('should transform to uppercase', () => {

--- a/src/__tests__/actions.spec.ts
+++ b/src/__tests__/actions.spec.ts
@@ -455,6 +455,13 @@ describe('Code Editor Shortcuts: actions', () => {
       expect(cursor.line).toEqual(0);
     });
 
+    it('should delete to the end of the line', () => {
+      deleteToEndOfLine(editor as any);
+
+      const { doc } = getDocumentAndSelection(editor);
+      expect(doc).toEqual('lorem ipsum\ndolor\namet');
+    });
+
     it('should join next line to current line', () => {
       joinLines(editor as any);
 
@@ -526,6 +533,42 @@ describe('Code Editor Shortcuts: actions', () => {
       expect(doc).toEqual(originalDoc);
       expect(cursor.line).toEqual(1);
       expect(cursor.ch).toEqual(9);
+    });
+
+    it('should navigate to the previous line', () => {
+      navigateLine(editor as any, 'up');
+
+      const { doc, cursor } = getDocumentAndSelection(editor);
+      expect(doc).toEqual(originalDoc);
+      expect(cursor.line).toEqual(0);
+      expect(cursor.ch).toEqual(5);
+    });
+
+    it('should navigate to the next line', () => {
+      navigateLine(editor as any, 'down');
+
+      const { doc, cursor } = getDocumentAndSelection(editor);
+      expect(doc).toEqual(originalDoc);
+      expect(cursor.line).toEqual(2);
+      expect(cursor.ch).toEqual(4);
+    });
+
+    it('should navigate the cursor backward', () => {
+      moveCursor(editor as any, 'backward');
+
+      const { doc, cursor } = getDocumentAndSelection(editor);
+      expect(doc).toEqual(originalDoc);
+      expect(cursor.line).toEqual(1);
+      expect(cursor.ch).toEqual(4);
+    });
+
+    it('should navigate the cursor forward', () => {
+      moveCursor(editor as any, 'forward');
+
+      const { doc, cursor } = getDocumentAndSelection(editor);
+      expect(doc).toEqual(originalDoc);
+      expect(cursor.line).toEqual(1);
+      expect(cursor.ch).toEqual(6);
     });
 
     it('should transform to uppercase', () => {

--- a/src/__tests__/actions.spec.ts
+++ b/src/__tests__/actions.spec.ts
@@ -242,6 +242,16 @@ describe('Code Editor Shortcuts: actions', () => {
       expect(cursor.ch).toEqual(0);
     });
 
+    it('should not navigate past the end of the document', () => {
+      editor.setCursor({ line: 2, ch: 4 });
+      navigateLine(editor as any, 'down');
+
+      const { doc, cursor } = getDocumentAndSelection(editor);
+      expect(doc).toEqual(originalDoc);
+      expect(cursor.line).toEqual(2);
+      expect(cursor.ch).toEqual(4);
+    });
+
     it('should snap to the end of the line', () => {
       editor.setValue('line zero\nzz\nline two');
       editor.setCursor({ line: 0, ch: 5 });

--- a/src/__tests__/actions.spec.ts
+++ b/src/__tests__/actions.spec.ts
@@ -10,6 +10,7 @@ import {
   selectWord,
   selectLine,
   goToLineBoundary,
+  navigateLine,
   transformCase,
   expandSelectionToBrackets,
   expandSelectionToQuotes,
@@ -184,6 +185,46 @@ describe('Code Editor Shortcuts: actions', () => {
       expect(doc).toEqual(originalDoc);
       expect(cursor.line).toEqual(1);
       expect(cursor.ch).toEqual(9);
+    });
+
+    it('should navigate to the previous line', () => {
+      editor.setCursor({ line: 2, ch: 0 });
+      navigateLine(editor as any, 'up');
+
+      const { doc, cursor } = getDocumentAndSelection(editor);
+      expect(doc).toEqual(originalDoc);
+      expect(cursor.line).toEqual(1);
+      expect(cursor.ch).toEqual(0);
+    });
+
+    it('should not navigate past the start of the document', () => {
+      editor.setCursor({ line: 0, ch: 0 });
+      navigateLine(editor as any, 'up');
+
+      const { doc, cursor } = getDocumentAndSelection(editor);
+      expect(doc).toEqual(originalDoc);
+      expect(cursor.line).toEqual(0);
+      expect(cursor.ch).toEqual(0);
+    });
+
+    it('should navigate to the next line', () => {
+      navigateLine(editor as any, 'down');
+
+      const { doc, cursor } = getDocumentAndSelection(editor);
+      expect(doc).toEqual(originalDoc);
+      expect(cursor.line).toEqual(2);
+      expect(cursor.ch).toEqual(0);
+    });
+
+    it('should snap to the end of the line', () => {
+      editor.setValue('line zero\nzz\nline two');
+      editor.setCursor({ line: 0, ch: 5 });
+
+      navigateLine(editor as any, 'down');
+
+      const { cursor } = getDocumentAndSelection(editor);
+      expect(cursor.line).toEqual(1);
+      expect(cursor.ch).toEqual(2);
     });
 
     it('should transform to uppercase', () => {

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -137,13 +137,12 @@ export const goToLineBoundary = (editor: Editor, boundary: 'start' | 'end') => {
 };
 
 export const navigateLine = (editor: Editor, direction: 'up' | 'down') => {
-  let pos, line;
+  const pos = editor.getCursor();
+  let line;
 
   if (direction === 'up') {
-    pos = editor.getCursor('from');
     line = Math.max(pos.line - 1, 0);
   } else {
-    pos = editor.getCursor('to');
     line = pos.line + 1;
   }
 
@@ -154,7 +153,7 @@ export const navigateLine = (editor: Editor, direction: 'up' | 'down') => {
 };
 
 export const moveCursor = (editor: Editor, direction: DIRECTION) => {
-  const { line, ch } = editor.getCursor('to');
+  const { line, ch } = editor.getCursor();
 
   const movement = direction === DIRECTION.BACKWARD ? -1 : 1;
   const lineLength = editor.getLine(line).length;

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -123,6 +123,23 @@ export const goToLineBoundary = (editor: Editor, boundary: 'start' | 'end') => {
   }
 };
 
+export const navigateLine = (editor: Editor, direction: 'up' | 'down') => {
+  let pos, line;
+
+  if (direction === 'up') {
+    pos = editor.getCursor('from');
+    line = Math.max(pos.line - 1, 0);
+  } else {
+    pos = editor.getCursor('to');
+    line = pos.line + 1;
+  }
+
+  const endOfLine = getLineEndPos(line, editor);
+  const ch = Math.min(pos.ch, endOfLine.ch);
+
+  editor.setSelection({ line, ch });
+};
+
 export const transformCase = (editor: Editor, caseType: CASE) => {
   const originalSelections = editor.listSelections();
   let selectedText = editor.getSelection();

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -138,7 +138,7 @@ export const goToLineBoundary = (editor: Editor, boundary: 'start' | 'end') => {
 
 export const navigateLine = (editor: Editor, direction: 'up' | 'down') => {
   const pos = editor.getCursor();
-  let line;
+  let line: number;
 
   if (direction === 'up') {
     line = Math.max(pos.line - 1, 0);

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -54,6 +54,19 @@ export const deleteSelectedLines = (editor: Editor) => {
   }
 };
 
+export const deleteToEndOfLine = (editor: Editor) => {
+  const pos = editor.getCursor();
+  const endPos = getLineEndPos(pos.line, editor);
+
+  if (pos.line === endPos.line && pos.ch === endPos.ch) {
+    // We're at the end of the line so delete just the newline
+    endPos.line = endPos.line + 1;
+    endPos.ch = 0;
+  }
+
+  editor.replaceRange('', pos, endPos);
+};
+
 export const joinLines = (editor: Editor) => {
   const { line } = editor.getCursor();
   const contentsOfNextLine = editor.getLine(line + 1).trimStart();

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -143,7 +143,7 @@ export const navigateLine = (editor: Editor, direction: 'up' | 'down') => {
   if (direction === 'up') {
     line = Math.max(pos.line - 1, 0);
   } else {
-    line = pos.line + 1;
+    line = Math.min(pos.line + 1, editor.lineCount() - 1);
   }
 
   const endOfLine = getLineEndPos(line, editor);

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -140,6 +140,29 @@ export const navigateLine = (editor: Editor, direction: 'up' | 'down') => {
   editor.setSelection({ line, ch });
 };
 
+export const moveCursor = (editor: Editor, direction: DIRECTION) => {
+  const { line, ch } = editor.getCursor('to');
+
+  const movement = direction === DIRECTION.BACKWARD ? -1 : 1;
+  const lineLength = editor.getLine(line).length;
+  const newPos = { line, ch: ch + movement };
+
+  if (newPos.ch < 0 && newPos.line === 0) {
+    // Moving backward past start of doc, do nothing
+    newPos.ch = ch;
+  } else if (newPos.ch < 0) {
+    // Wrap backward over start of line
+    newPos.line = Math.max(newPos.line - 1, 0);
+    newPos.ch = editor.getLine(newPos.line).length;
+  } else if (newPos.ch > lineLength) {
+    // Wrap forward over end of line
+    newPos.line += 1;
+    newPos.ch = 0;
+  }
+
+  editor.setSelection(newPos);
+};
+
 export const transformCase = (editor: Editor, caseType: CASE) => {
   const originalSelections = editor.listSelections();
   let selectedText = editor.getSelection();

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import { Plugin } from 'obsidian';
 import {
   copyLine,
   deleteSelectedLines,
+  deleteToEndOfLine,
   expandSelectionToBrackets,
   expandSelectionToQuotes,
   goToHeading,
@@ -53,6 +54,12 @@ export default class CodeEditorShortcuts extends Plugin {
         },
       ],
       editorCallback: (editor) => deleteSelectedLines(editor),
+    });
+
+    this.addCommand({
+      id: 'deleteToEndOfLine',
+      name: 'Delete to end of line',
+      editorCallback: (editor) => deleteToEndOfLine(editor),
     });
 
     this.addCommand({

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,12 +9,13 @@ import {
   insertLineAbove,
   insertLineBelow,
   joinLines,
+  moveCursor,
   navigateLine,
   selectLine,
   selectWord,
   transformCase,
 } from './actions';
-import { CASE } from './constants';
+import { CASE, DIRECTION } from './constants';
 
 export default class CodeEditorShortcuts extends Plugin {
   onload() {
@@ -142,6 +143,18 @@ export default class CodeEditorShortcuts extends Plugin {
       id: 'goToPrevLine',
       name: 'Go to previous line',
       editorCallback: (editor) => navigateLine(editor, 'up'),
+    });
+
+    this.addCommand({
+      id: 'goToNextChar',
+      name: 'Move cursor forward',
+      editorCallback: (editor) => moveCursor(editor, DIRECTION.FORWARD),
+    });
+
+    this.addCommand({
+      id: 'goToPrevChar',
+      name: 'Move cursor backward',
+      editorCallback: (editor) => moveCursor(editor, DIRECTION.BACKWARD),
     });
 
     this.addCommand({

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,7 @@ import {
   insertLineAbove,
   insertLineBelow,
   joinLines,
+  navigateLine,
   selectLine,
   selectWord,
   transformCase,
@@ -129,6 +130,18 @@ export default class CodeEditorShortcuts extends Plugin {
       id: 'goToLineEnd',
       name: 'Go to end of line',
       editorCallback: (editor) => goToLineBoundary(editor, 'end'),
+    });
+
+    this.addCommand({
+      id: 'goToNextLine',
+      name: 'Go to next line',
+      editorCallback: (editor) => navigateLine(editor, 'down'),
+    });
+
+    this.addCommand({
+      id: 'goToPrevLine',
+      name: 'Go to previous line',
+      editorCallback: (editor) => navigateLine(editor, 'up'),
     });
 
     this.addCommand({


### PR DESCRIPTION
Hello!

I've made some additions in this PR to add support for some common Emacs shortcuts (without adding any default hotkeys). Would that be something you'd be open to merging into the plugin?

I'm fairly new to CodeMirror, so I'm sure there are better ways to do everything - let me know if you see anything that could be simpler. Thank you!