### PR TITLE
Minor Tweaks: Expand to bracket or quote // joining lines removes list markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This [Obsidian](https://obsidian.md) plugin adds keyboard shortcuts (hotkeys) co
 | Transform selection to title case                | Not set                    |
 | Expand selection to brackets                     | Not set                    |
 | Expand selection to quotes                       | Not set                    |
+| Expand selection to quotes or brackets           | Not set                    |
 | Go to next heading                               | Not set                    |
 | Go to previous heading                           | Not set                    |
 

--- a/README.md
+++ b/README.md
@@ -33,11 +33,12 @@ This [Obsidian](https://obsidian.md) plugin adds keyboard shortcuts (hotkeys) co
 
 \*\* This may conflict with the default shortcut for _Toggle checklist status_; changing/removing one of the bindings is recommended
 
-If you are looking for the `Alt` + `Up` and `Alt` + `Down` shortcuts from VS Code, you can assign those hotkeys to Obsidian's built in actions "Move line up" and "Move line down".
+These shortcuts also work with [multiple cursors](https://help.obsidian.md/How+to/Working+with+multiple+cursors), with the exception of:
 
----
+- Expand selection to quotes or brackets
+- Go to next/previous heading
 
-_Note: these shortcuts also work with [multiple cursors](https://help.obsidian.md/How+to/Working+with+multiple+cursors)_, with the exception of "Go to next/previous heading".
+_Note:_ If you are looking for the `Alt` + `Up` and `Alt` + `Down` shortcuts from VS Code, you can assign those hotkeys to Obsidian's built in actions "Move line up" and "Move line down".
 
 ## Installing the plugin
 

--- a/src/__tests__/actions-cursor.spec.ts
+++ b/src/__tests__/actions-cursor.spec.ts
@@ -517,7 +517,7 @@ describe('Code Editor Shortcuts: actions - single cursor selection', () => {
       editor.setValue(content);
       editor.setCursor({ line: 0, ch: 7 });
 
-      withMultipleSelections(editor as any, expandSelectionToQuotesOrBrackets);
+      expandSelectionToQuotesOrBrackets(editor as any);
 
       const { doc, selectedText } = getDocumentAndSelection(editor);
       expect(doc).toEqual(content);

--- a/src/__tests__/actions-cursor.spec.ts
+++ b/src/__tests__/actions-cursor.spec.ts
@@ -16,6 +16,7 @@ import {
   transformCase,
   expandSelectionToBrackets,
   expandSelectionToQuotes,
+  expandSelectionToQuotesOrBrackets,
 } from '../actions';
 import { CASE, DIRECTION } from '../constants';
 import { withMultipleSelections } from '../utils';
@@ -505,6 +506,22 @@ describe('Code Editor Shortcuts: actions - single cursor selection', () => {
       const { doc, selectedText } = getDocumentAndSelection(editor);
       expect(doc).toEqual(content);
       expect(selectedText).toEqual('');
+    });
+  });
+
+  describe('expandSelectionToQuotesOrBrackets', () => {
+    it.each([
+      ['quotes', '("lorem ipsum" dolor)'],
+      ['brackets', '"(lorem ipsum) dolor"'],
+    ])('should expand selection to %s', (_scenario, content) => {
+      editor.setValue(content);
+      editor.setCursor({ line: 0, ch: 7 });
+
+      withMultipleSelections(editor as any, expandSelectionToQuotesOrBrackets);
+
+      const { doc, selectedText } = getDocumentAndSelection(editor);
+      expect(doc).toEqual(content);
+      expect(selectedText).toEqual('lorem ipsum');
     });
   });
 });

--- a/src/__tests__/actions-cursor.spec.ts
+++ b/src/__tests__/actions-cursor.spec.ts
@@ -157,6 +157,21 @@ describe('Code Editor Shortcuts: actions - single cursor selection', () => {
       expect(cursor.line).toEqual(1);
       expect(cursor.ch).toEqual(9);
     });
+
+    it('should remove markdown list characters', () => {
+      const content = '- aaa\n* bbb\n+ ccc\n~ ddd';
+      editor.setValue(content);
+      editor.setCursor({ line: 0, ch: 0 });
+
+      withMultipleSelections(editor as any, joinLines);
+      withMultipleSelections(editor as any, joinLines);
+      withMultipleSelections(editor as any, joinLines);
+
+      const { doc, cursor } = getDocumentAndSelection(editor);
+      expect(doc).toEqual('- aaa bbb ccc ~ ddd');
+      expect(cursor.line).toEqual(0);
+      expect(cursor.ch).toEqual(13);
+    });
   });
 
   describe('copyLine', () => {

--- a/src/__tests__/actions-multi.spec.ts
+++ b/src/__tests__/actions-multi.spec.ts
@@ -215,6 +215,30 @@ describe('Code Editor Shortcuts: actions - multiple mixed selections', () => {
         },
       ]);
     });
+
+    it('should remove markdown list characters', () => {
+      const content = '- aaa\n- bbb\n- ccc\n- ddd';
+      editor.setValue(content);
+      editor.setSelections([
+        { anchor: { line: 0, ch: 3 }, head: { line: 0, ch: 3 } },
+        { anchor: { line: 2, ch: 4 }, head: { line: 2, ch: 4 } },
+      ]);
+
+      withMultipleSelections(editor as any, joinLines);
+
+      const { doc, selections } = getDocumentAndSelection(editor);
+      expect(doc).toEqual('- aaa bbb\n- ccc ddd');
+      expect(selections).toEqual([
+        {
+          anchor: expect.objectContaining({ line: 0, ch: 5 }),
+          head: expect.objectContaining({ line: 0, ch: 5 }),
+        },
+        {
+          anchor: expect.objectContaining({ line: 1, ch: 5 }),
+          head: expect.objectContaining({ line: 1, ch: 5 }),
+        },
+      ]);
+    });
   });
 
   describe('copyLine', () => {

--- a/src/__tests__/actions-range.spec.ts
+++ b/src/__tests__/actions-range.spec.ts
@@ -354,7 +354,7 @@ describe('Code Editor Shortcuts: actions - single range selection', () => {
       editor.setValue(content);
       editor.setSelection({ line: 0, ch: 8 }, { line: 0, ch: 13 });
 
-      withMultipleSelections(editor as any, expandSelectionToQuotesOrBrackets);
+      expandSelectionToQuotesOrBrackets(editor as any);
 
       const { doc, selectedText } = getDocumentAndSelection(editor);
       expect(doc).toEqual(content);

--- a/src/__tests__/actions-range.spec.ts
+++ b/src/__tests__/actions-range.spec.ts
@@ -16,6 +16,7 @@ import {
   transformCase,
   expandSelectionToBrackets,
   expandSelectionToQuotes,
+  expandSelectionToQuotesOrBrackets,
 } from '../actions';
 import { CASE, DIRECTION } from '../constants';
 import { withMultipleSelections } from '../utils';
@@ -342,6 +343,22 @@ describe('Code Editor Shortcuts: actions - single range selection', () => {
       const { doc, selectedText } = getDocumentAndSelection(editor);
       expect(doc).toEqual(content);
       expect(selectedText).toEqual('um"\ndo');
+    });
+  });
+
+  describe('expandSelectionToQuotesOrBrackets', () => {
+    it.each([
+      ['quotes', '("lorem ipsum" dolor)'],
+      ['brackets', '"(lorem ipsum) dolor"'],
+    ])('should expand selection to %s', (_scenario, content) => {
+      editor.setValue(content);
+      editor.setSelection({ line: 0, ch: 8 }, { line: 0, ch: 13 });
+
+      withMultipleSelections(editor as any, expandSelectionToQuotesOrBrackets);
+
+      const { doc, selectedText } = getDocumentAndSelection(editor);
+      expect(doc).toEqual(content);
+      expect(selectedText).toEqual('lorem ipsum');
     });
   });
 });

--- a/src/__tests__/actions-range.spec.ts
+++ b/src/__tests__/actions-range.spec.ts
@@ -98,6 +98,21 @@ describe('Code Editor Shortcuts: actions - single range selection', () => {
       expect(cursor.line).toEqual(1);
       expect(cursor.ch).toEqual(9);
     });
+
+    it('should remove markdown list characters', () => {
+      const content = '- aaa\n- bbb\n- ccc';
+      editor.setValue(content);
+      editor.setSelection({ line: 1, ch: 4 }, { line: 0, ch: 3 });
+
+      withMultipleSelections(editor as any, joinLines);
+
+      const { doc, selections } = getDocumentAndSelection(editor);
+      expect(doc).toEqual('- aaa bbb\n- ccc');
+      expect(selections[0]).toEqual({
+        anchor: expect.objectContaining({ line: 0, ch: 5 }),
+        head: expect.objectContaining({ line: 0, ch: 5 }),
+      });
+    });
   });
 
   describe('copyLine', () => {

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -76,7 +76,7 @@ export const joinLines = (editor: Editor, selection: EditorSelection) => {
   const { line } = selection.head;
   const contentsOfNextLine = editor
     .getLine(line + 1)
-    .replace(/^\s*(?:- )?/, '');
+    .replace(/^\s*((-|\+|\*|\d+\.) )?/, '');
   const endOfCurrentLine = getLineEndPos(line, editor);
   const endOfNextLine = getLineEndPos(line + 1, editor);
   editor.replaceRange(

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -5,6 +5,7 @@ import {
   LOWERCASE_ARTICLES,
   MATCHING_BRACKETS,
   MATCHING_QUOTES,
+  MATCHING_QUOTES_BRACKETS,
   MatchingCharacterMap,
 } from './constants';
 import {
@@ -297,6 +298,17 @@ export const expandSelectionToQuotes = (
     selection,
     openingCharacterCheck: (char: string) => /['"`]/.test(char),
     matchingCharacterMap: MATCHING_QUOTES,
+  });
+
+export const expandSelectionToQuotesOrBrackets = (
+  editor: Editor,
+  selection: EditorSelection,
+) =>
+  expandSelection({
+    editor,
+    selection,
+    openingCharacterCheck: (char: string) => /['"`([{]/.test(char),
+    matchingCharacterMap: MATCHING_QUOTES_BRACKETS,
   });
 
 export const goToHeading = (

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -302,16 +302,16 @@ export const expandSelectionToQuotes = (
     matchingCharacterMap: MATCHING_QUOTES,
   });
 
-export const expandSelectionToQuotesOrBrackets = (
-  editor: Editor,
-  selection: EditorSelection,
-) =>
-  expandSelection({
+export const expandSelectionToQuotesOrBrackets = (editor: Editor) => {
+  const selections = editor.listSelections();
+  const newSelection = expandSelection({
     editor,
-    selection,
+    selection: selections[0],
     openingCharacterCheck: (char: string) => /['"`([{]/.test(char),
     matchingCharacterMap: MATCHING_QUOTES_BRACKETS,
   });
+  editor.setSelections([...selections, newSelection]);
+};
 
 export const goToHeading = (
   app: App,

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -74,7 +74,9 @@ export const deleteToEndOfLine = (
 
 export const joinLines = (editor: Editor, selection: EditorSelection) => {
   const { line } = selection.head;
-  const contentsOfNextLine = editor.getLine(line + 1).trimStart();
+  const contentsOfNextLine = editor
+    .getLine(line + 1)
+    .replace(/^\s*(?:- )?/, '');
   const endOfCurrentLine = getLineEndPos(line, editor);
   const endOfNextLine = getLineEndPos(line + 1, editor);
   editor.replaceRange(

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -24,3 +24,12 @@ export const MATCHING_QUOTES: MatchingCharacterMap = {
   '"': '"',
   '`': '`',
 };
+
+export const MATCHING_QUOTES_BRACKETS: MatchingCharacterMap = {
+  "'": "'",
+  '"': '"',
+  '`': '`',
+  '[': ']',
+  '(': ')',
+  '{': '}',
+};

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -26,10 +26,6 @@ export const MATCHING_QUOTES: MatchingCharacterMap = {
 };
 
 export const MATCHING_QUOTES_BRACKETS: MatchingCharacterMap = {
-  "'": "'",
-  '"': '"',
-  '`': '`',
-  '[': ']',
-  '(': ')',
-  '{': '}',
+  ...MATCHING_QUOTES,
+  ...MATCHING_BRACKETS,
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -264,8 +264,7 @@ export default class CodeEditorShortcuts extends Plugin {
     this.addCommand({
       id: 'expandSelectionToQuotesOrBrackets',
       name: 'Expand selection to quotes or brackets',
-      editorCallback: (editor) =>
-        withMultipleSelections(editor, expandSelectionToQuotesOrBrackets),
+      editorCallback: (editor) => expandSelectionToQuotesOrBrackets(editor),
     });
 
     this.addCommand({

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,7 @@ import {
   deleteToEndOfLine,
   expandSelectionToBrackets,
   expandSelectionToQuotes,
+  expandSelectionToQuotesOrBrackets,
   goToHeading,
   goToLineBoundary,
   insertLineAbove,
@@ -258,6 +259,13 @@ export default class CodeEditorShortcuts extends Plugin {
       name: 'Expand selection to quotes',
       editorCallback: (editor) =>
         withMultipleSelections(editor, expandSelectionToQuotes),
+    });
+
+    this.addCommand({
+      id: 'expandSelectionToQuotesOrBrackets',
+      name: 'Expand selection to quotes or brackets',
+      editorCallback: (editor) =>
+        withMultipleSelections(editor, expandSelectionToQuotesOrBrackets),
     });
 
     this.addCommand({


### PR DESCRIPTION
two minor additions, basically closing #7 and #21 (coincidentally created by me 😝 ).

However, I did have trouble building the plugin on my end. After building, no command works – even the ones I did not modify. However, the changes are pretty straightforward, and `yarn.test` passed all tests, so I assume that everything should be fine? 😅 

For reference what happened on my end: ⬇️ 

---

When running a command, I get the following error in the console, probably referring to [`.cm.operation` here](https://github.com/chrisgrieser/obsidian-editor-shortcuts/blob/master/src/utils.ts#L74), but I have no idea what's missing here. In my main vault, where I use the last public release of Code Editor Shortcuts, all commands work fine though. :confused:

```js
app.js:1 TypeError: cm.operation is not a function
    at withMultipleSelections (eval at <anonymous> (app.js:1:1444405), <anonymous>:111:8)
    at Object.editorCallback (eval at <anonymous> (app.js:1:1444405), <anonymous>:619:35)
    at Object.e.mobileOnly.kb.isMobile.e.checkCallback (app.js:1:1566335)
    at rz (app.js:1:1565804)
    at e.executeCommandById (app.js:1:1567080)
    at e.onTrigger (app.js:1:1098107)
    at e.handleKey (app.js:1:864568)
    at t.e.handleKey (app.js:1:864681)
    at t.handleKey (app.js:1:864890)
    at e.onKeyEvent (app.js:1:865683)
```

I assume I did something wrong while building? For reference, since I have no prior experience with nvm and/or yarn, this is the code I ran, where I never got an error during one of these.

```zsh
# install yarn + nvm
brew install yarn
curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash

# build
nvm use # prompts to install the missing version
nvm install 12.22.4
nvm use
yarn install
yarn start
# Cancel with ^C
yarn test # all test passed

# git
git add -A
git commit -m "..."
git push # to my fork
```