### PR TITLE
Implement go to first/last line

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ This [Obsidian](https://obsidian.md) plugin adds keyboard shortcuts (hotkeys) co
 | Go to end of line                                | Not set                    |
 | Go to previous line                              | Not set                    |
 | Go to next line                                  | Not set                    |
+| Go to first line                                 | Not set                    |
+| Go to last line                                  | Not set                    |
 | Delete to start of line                          | Not set                    |
 | Delete to end of line                            | Not set                    |
 | Transform selection to uppercase                 | Not set                    |

--- a/src/__tests__/actions-cursor.spec.ts
+++ b/src/__tests__/actions-cursor.spec.ts
@@ -701,7 +701,7 @@ describe('Code Editor Shortcuts: actions - single cursor selection', () => {
       const { doc, cursor } = getDocumentAndSelection(editor);
       expect(doc).toEqual(originalDoc);
       expect(cursor.line).toEqual(2);
-      expect(cursor.ch).toEqual(0);
+      expect(cursor.ch).toEqual(4);
     });
   });
 

--- a/src/__tests__/actions-cursor.spec.ts
+++ b/src/__tests__/actions-cursor.spec.ts
@@ -687,7 +687,7 @@ describe('Code Editor Shortcuts: actions - single cursor selection', () => {
     });
 
     it('should navigate to the first line', () => {
-      withMultipleSelections(editor as any, navigateLine, { args: 'top' });
+      withMultipleSelections(editor as any, navigateLine, { args: 'first' });
 
       const { doc, cursor } = getDocumentAndSelection(editor);
       expect(doc).toEqual(originalDoc);
@@ -696,7 +696,7 @@ describe('Code Editor Shortcuts: actions - single cursor selection', () => {
     });
 
     it('should navigate to the last line', () => {
-      withMultipleSelections(editor as any, navigateLine, { args: 'bottom' });
+      withMultipleSelections(editor as any, navigateLine, { args: 'last' });
 
       const { doc, cursor } = getDocumentAndSelection(editor);
       expect(doc).toEqual(originalDoc);

--- a/src/__tests__/actions-cursor.spec.ts
+++ b/src/__tests__/actions-cursor.spec.ts
@@ -638,7 +638,7 @@ describe('Code Editor Shortcuts: actions - single cursor selection', () => {
   describe('navigateLine', () => {
     it('should navigate to the previous line', () => {
       editor.setCursor({ line: 2, ch: 0 });
-      withMultipleSelections(editor as any, navigateLine, { args: 'up' });
+      withMultipleSelections(editor as any, navigateLine, { args: 'prev' });
 
       const { doc, cursor } = getDocumentAndSelection(editor);
       expect(doc).toEqual(originalDoc);
@@ -648,7 +648,7 @@ describe('Code Editor Shortcuts: actions - single cursor selection', () => {
 
     it('should not navigate past the start of the document', () => {
       editor.setCursor({ line: 0, ch: 0 });
-      withMultipleSelections(editor as any, navigateLine, { args: 'up' });
+      withMultipleSelections(editor as any, navigateLine, { args: 'prev' });
 
       const { doc, cursor } = getDocumentAndSelection(editor);
       expect(doc).toEqual(originalDoc);
@@ -657,7 +657,7 @@ describe('Code Editor Shortcuts: actions - single cursor selection', () => {
     });
 
     it('should navigate to the next line', () => {
-      withMultipleSelections(editor as any, navigateLine, { args: 'down' });
+      withMultipleSelections(editor as any, navigateLine, { args: 'next' });
 
       const { doc, cursor } = getDocumentAndSelection(editor);
       expect(doc).toEqual(originalDoc);
@@ -667,7 +667,7 @@ describe('Code Editor Shortcuts: actions - single cursor selection', () => {
 
     it('should not navigate past the end of the document', () => {
       editor.setCursor({ line: 2, ch: 4 });
-      withMultipleSelections(editor as any, navigateLine, { args: 'down' });
+      withMultipleSelections(editor as any, navigateLine, { args: 'next' });
 
       const { doc, cursor } = getDocumentAndSelection(editor);
       expect(doc).toEqual(originalDoc);
@@ -679,11 +679,29 @@ describe('Code Editor Shortcuts: actions - single cursor selection', () => {
       editor.setValue('line zero\nzz\nline two');
       editor.setCursor({ line: 0, ch: 5 });
 
-      withMultipleSelections(editor as any, navigateLine, { args: 'down' });
+      withMultipleSelections(editor as any, navigateLine, { args: 'next' });
 
       const { cursor } = getDocumentAndSelection(editor);
       expect(cursor.line).toEqual(1);
       expect(cursor.ch).toEqual(2);
+    });
+
+    it('should navigate to the first line', () => {
+      withMultipleSelections(editor as any, navigateLine, { args: 'top' });
+
+      const { doc, cursor } = getDocumentAndSelection(editor);
+      expect(doc).toEqual(originalDoc);
+      expect(cursor.line).toEqual(0);
+      expect(cursor.ch).toEqual(0);
+    });
+
+    it('should navigate to the last line', () => {
+      withMultipleSelections(editor as any, navigateLine, { args: 'bottom' });
+
+      const { doc, cursor } = getDocumentAndSelection(editor);
+      expect(doc).toEqual(originalDoc);
+      expect(cursor.line).toEqual(2);
+      expect(cursor.ch).toEqual(0);
     });
   });
 

--- a/src/__tests__/actions-multi.spec.ts
+++ b/src/__tests__/actions-multi.spec.ts
@@ -530,7 +530,7 @@ describe('Code Editor Shortcuts: actions - multiple mixed selections', () => {
     it('should navigate to the previous lines', () => {
       withMultipleSelections(editor as any, navigateLine, {
         ...defaultMultipleSelectionOptions,
-        args: 'up',
+        args: 'prev',
       });
 
       const { doc, selections } = getDocumentAndSelection(editor);
@@ -554,7 +554,7 @@ describe('Code Editor Shortcuts: actions - multiple mixed selections', () => {
     it('should navigate to the next lines', () => {
       withMultipleSelections(editor as any, navigateLine, {
         ...defaultMultipleSelectionOptions,
-        args: 'down',
+        args: 'next',
       });
 
       const { doc, selections } = getDocumentAndSelection(editor);
@@ -571,6 +571,54 @@ describe('Code Editor Shortcuts: actions - multiple mixed selections', () => {
         {
           anchor: expect.objectContaining({ line: 5, ch: 16 }),
           head: expect.objectContaining({ line: 5, ch: 16 }),
+        },
+      ]);
+    });
+
+    it('should navigate to the first line', () => {
+      withMultipleSelections(editor as any, navigateLine, {
+        ...defaultMultipleSelectionOptions,
+        args: 'top',
+      });
+
+      const { doc, selections } = getDocumentAndSelection(editor);
+      expect(doc).toEqual(originalDoc);
+      expect(selections).toEqual([
+        {
+          anchor: expect.objectContaining({ line: 0, ch: 2 }),
+          head: expect.objectContaining({ line: 0, ch: 2 }),
+        },
+        {
+          anchor: expect.objectContaining({ line: 0, ch: 6 }),
+          head: expect.objectContaining({ line: 0, ch: 6 }),
+        },
+        {
+          anchor: expect.objectContaining({ line: 0, ch: 11 }),
+          head: expect.objectContaining({ line: 0, ch: 11 }),
+        },
+      ]);
+    });
+
+    it('should navigate to the last line', () => {
+      withMultipleSelections(editor as any, navigateLine, {
+        ...defaultMultipleSelectionOptions,
+        args: 'bottom',
+      });
+
+      const { doc, selections } = getDocumentAndSelection(editor);
+      expect(doc).toEqual(originalDoc);
+      expect(selections).toEqual([
+        {
+          anchor: expect.objectContaining({ line: 6, ch: 2 }),
+          head: expect.objectContaining({ line: 6, ch: 2 }),
+        },
+        {
+          anchor: expect.objectContaining({ line: 6, ch: 6 }),
+          head: expect.objectContaining({ line: 6, ch: 6 }),
+        },
+        {
+          anchor: expect.objectContaining({ line: 6, ch: 15 }),
+          head: expect.objectContaining({ line: 6, ch: 15 }),
         },
       ]);
     });

--- a/src/__tests__/actions-multi.spec.ts
+++ b/src/__tests__/actions-multi.spec.ts
@@ -578,7 +578,7 @@ describe('Code Editor Shortcuts: actions - multiple mixed selections', () => {
     it('should navigate to the first line', () => {
       withMultipleSelections(editor as any, navigateLine, {
         ...defaultMultipleSelectionOptions,
-        args: 'top',
+        args: 'first',
       });
 
       const { doc, selections } = getDocumentAndSelection(editor);
@@ -602,7 +602,7 @@ describe('Code Editor Shortcuts: actions - multiple mixed selections', () => {
     it('should navigate to the last line', () => {
       withMultipleSelections(editor as any, navigateLine, {
         ...defaultMultipleSelectionOptions,
-        args: 'bottom',
+        args: 'last',
       });
 
       const { doc, selections } = getDocumentAndSelection(editor);

--- a/src/__tests__/actions-multi.spec.ts
+++ b/src/__tests__/actions-multi.spec.ts
@@ -585,16 +585,8 @@ describe('Code Editor Shortcuts: actions - multiple mixed selections', () => {
       expect(doc).toEqual(originalDoc);
       expect(selections).toEqual([
         {
-          anchor: expect.objectContaining({ line: 0, ch: 2 }),
-          head: expect.objectContaining({ line: 0, ch: 2 }),
-        },
-        {
-          anchor: expect.objectContaining({ line: 0, ch: 6 }),
-          head: expect.objectContaining({ line: 0, ch: 6 }),
-        },
-        {
-          anchor: expect.objectContaining({ line: 0, ch: 11 }),
-          head: expect.objectContaining({ line: 0, ch: 11 }),
+          anchor: expect.objectContaining({ line: 0, ch: 0 }),
+          head: expect.objectContaining({ line: 0, ch: 0 }),
         },
       ]);
     });
@@ -608,14 +600,6 @@ describe('Code Editor Shortcuts: actions - multiple mixed selections', () => {
       const { doc, selections } = getDocumentAndSelection(editor);
       expect(doc).toEqual(originalDoc);
       expect(selections).toEqual([
-        {
-          anchor: expect.objectContaining({ line: 6, ch: 2 }),
-          head: expect.objectContaining({ line: 6, ch: 2 }),
-        },
-        {
-          anchor: expect.objectContaining({ line: 6, ch: 6 }),
-          head: expect.objectContaining({ line: 6, ch: 6 }),
-        },
         {
           anchor: expect.objectContaining({ line: 6, ch: 15 }),
           head: expect.objectContaining({ line: 6, ch: 15 }),

--- a/src/__tests__/actions-range.spec.ts
+++ b/src/__tests__/actions-range.spec.ts
@@ -631,7 +631,7 @@ describe('Code Editor Shortcuts: actions - single range selection', () => {
       const { doc, cursor } = getDocumentAndSelection(editor);
       expect(doc).toEqual(originalDoc);
       expect(cursor.line).toEqual(0);
-      expect(cursor.ch).toEqual(5);
+      expect(cursor.ch).toEqual(0);
     });
 
     it('should navigate to the last line', () => {

--- a/src/__tests__/actions-range.spec.ts
+++ b/src/__tests__/actions-range.spec.ts
@@ -608,7 +608,7 @@ describe('Code Editor Shortcuts: actions - single range selection', () => {
 
   describe('navigateLine', () => {
     it('should navigate to the previous line', () => {
-      withMultipleSelections(editor as any, navigateLine, { args: 'up' });
+      withMultipleSelections(editor as any, navigateLine, { args: 'prev' });
 
       const { doc, cursor } = getDocumentAndSelection(editor);
       expect(doc).toEqual(originalDoc);
@@ -617,7 +617,25 @@ describe('Code Editor Shortcuts: actions - single range selection', () => {
     });
 
     it('should navigate to the next line', () => {
-      withMultipleSelections(editor as any, navigateLine, { args: 'down' });
+      withMultipleSelections(editor as any, navigateLine, { args: 'next' });
+
+      const { doc, cursor } = getDocumentAndSelection(editor);
+      expect(doc).toEqual(originalDoc);
+      expect(cursor.line).toEqual(2);
+      expect(cursor.ch).toEqual(4);
+    });
+
+    it('should navigate to the first line', () => {
+      withMultipleSelections(editor as any, navigateLine, { args: 'top' });
+
+      const { doc, cursor } = getDocumentAndSelection(editor);
+      expect(doc).toEqual(originalDoc);
+      expect(cursor.line).toEqual(0);
+      expect(cursor.ch).toEqual(5);
+    });
+
+    it('should navigate to the last line', () => {
+      withMultipleSelections(editor as any, navigateLine, { args: 'bottom' });
 
       const { doc, cursor } = getDocumentAndSelection(editor);
       expect(doc).toEqual(originalDoc);

--- a/src/__tests__/actions-range.spec.ts
+++ b/src/__tests__/actions-range.spec.ts
@@ -626,7 +626,7 @@ describe('Code Editor Shortcuts: actions - single range selection', () => {
     });
 
     it('should navigate to the first line', () => {
-      withMultipleSelections(editor as any, navigateLine, { args: 'top' });
+      withMultipleSelections(editor as any, navigateLine, { args: 'first' });
 
       const { doc, cursor } = getDocumentAndSelection(editor);
       expect(doc).toEqual(originalDoc);
@@ -635,7 +635,7 @@ describe('Code Editor Shortcuts: actions - single range selection', () => {
     });
 
     it('should navigate to the last line', () => {
-      withMultipleSelections(editor as any, navigateLine, { args: 'bottom' });
+      withMultipleSelections(editor as any, navigateLine, { args: 'last' });
 
       const { doc, cursor } = getDocumentAndSelection(editor);
       expect(doc).toEqual(originalDoc);

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -341,7 +341,7 @@ export const goToLineBoundary = (
 export const navigateLine = (
   editor: Editor,
   selection: EditorSelection,
-  position: 'next' | 'prev' | 'top' | 'bottom',
+  position: 'next' | 'prev' | 'first' | 'last',
 ) => {
   const pos = selection.head;
   let line: number;
@@ -352,10 +352,10 @@ export const navigateLine = (
   if (position === 'next') {
     line = Math.min(pos.line + 1, editor.lineCount() - 1);
   }
-  if (position === 'top') {
+  if (position === 'first') {
     line = 0;
   }
-  if (position === 'bottom') {
+  if (position === 'last') {
     line = editor.lineCount() - 1;
   }
 

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -341,15 +341,22 @@ export const goToLineBoundary = (
 export const navigateLine = (
   editor: Editor,
   selection: EditorSelection,
-  direction: 'up' | 'down',
+  position: 'next' | 'prev' | 'top' | 'bottom',
 ) => {
   const pos = selection.head;
   let line: number;
 
-  if (direction === 'up') {
+  if (position === 'prev') {
     line = Math.max(pos.line - 1, 0);
-  } else {
+  }
+  if (position === 'next') {
     line = Math.min(pos.line + 1, editor.lineCount() - 1);
+  }
+  if (position === 'top') {
+    line = 0;
+  }
+  if (position === 'bottom') {
+    line = editor.lineCount() - 1;
   }
 
   const endOfLine = getLineEndPos(line, editor);

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -345,22 +345,27 @@ export const navigateLine = (
 ) => {
   const pos = selection.head;
   let line: number;
+  let ch: number;
 
   if (position === 'prev') {
     line = Math.max(pos.line - 1, 0);
+    const endOfLine = getLineEndPos(line, editor);
+    ch = Math.min(pos.ch, endOfLine.ch);
   }
   if (position === 'next') {
     line = Math.min(pos.line + 1, editor.lineCount() - 1);
+    const endOfLine = getLineEndPos(line, editor);
+    ch = Math.min(pos.ch, endOfLine.ch);
   }
   if (position === 'first') {
     line = 0;
+    ch = 0;
   }
   if (position === 'last') {
     line = editor.lineCount() - 1;
+    const endOfLine = getLineEndPos(line, editor);
+    ch = endOfLine.ch;
   }
-
-  const endOfLine = getLineEndPos(line, editor);
-  const ch = Math.min(pos.ch, endOfLine.ch);
 
   return { anchor: { line, ch } };
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -257,7 +257,7 @@ export default class CodeEditorShortcuts extends Plugin {
       editorCallback: (editor) =>
         withMultipleSelections(editor, navigateLine, {
           ...defaultMultipleSelectionOptions,
-          args: 'top',
+          args: 'first',
         }),
     });
 
@@ -267,7 +267,7 @@ export default class CodeEditorShortcuts extends Plugin {
       editorCallback: (editor) =>
         withMultipleSelections(editor, navigateLine, {
           ...defaultMultipleSelectionOptions,
-          args: 'bottom',
+          args: 'last',
         }),
     });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -237,7 +237,7 @@ export default class CodeEditorShortcuts extends Plugin {
       editorCallback: (editor) =>
         withMultipleSelections(editor, navigateLine, {
           ...defaultMultipleSelectionOptions,
-          args: 'down',
+          args: 'next',
         }),
     });
 
@@ -247,7 +247,27 @@ export default class CodeEditorShortcuts extends Plugin {
       editorCallback: (editor) =>
         withMultipleSelections(editor, navigateLine, {
           ...defaultMultipleSelectionOptions,
-          args: 'up',
+          args: 'prev',
+        }),
+    });
+
+    this.addCommand({
+      id: 'goToFirstLine',
+      name: 'Go to first line',
+      editorCallback: (editor) =>
+        withMultipleSelections(editor, navigateLine, {
+          ...defaultMultipleSelectionOptions,
+          args: 'top',
+        }),
+    });
+
+    this.addCommand({
+      id: 'goToLastLine',
+      name: 'Go to last line',
+      editorCallback: (editor) =>
+        withMultipleSelections(editor, navigateLine, {
+          ...defaultMultipleSelectionOptions,
+          args: 'bottom',
         }),
     });
 


### PR DESCRIPTION
Mobile (iOS) has commands "Go to first line" and "Go to last line" but Desktop (macOS) does not.
This is a problem if one wants to create a common macro across devices using a community plugin like Commander.

I thought about creating another plugin, but I thought it would be beneficial for other users to have this feature included, so I 
created a pull request.

I hope you will consider merging this.